### PR TITLE
chore: update API base URLs to use production domain

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
-NEXT_PUBLIC_BASE_URL=http://64.23.193.89:5000
+# NEXT_PUBLIC_BASE_URL=http://64.23.193.89:5000
+NEXT_PUBLIC_BASE_URL=https://api.giftmein.com
 # NEXT_PUBLIC_BASE_URL=http://10.0.70.188:5000
 # NEXT_PUBLIC_BASE_URL=https://rakib.binarybards.online/
 # NEXT_PUBLIC_BASE_URL=https://rakib5001.binarybards.online/

--- a/src/redux/api/baseApi.ts
+++ b/src/redux/api/baseApi.ts
@@ -4,7 +4,8 @@ import Cookies from 'js-cookie';
 const api = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({
-    baseUrl: 'http://64.23.193.89:5000/api/v1/',
+    // baseUrl: 'http://64.23.193.89:5000/api/v1/',
+    baseUrl: 'https://api.giftmein.com/api/v1/',
     // baseUrl: 'http://10.0.70.188:5000/api/v1/',
     // baseUrl: 'http://10.0.70.188:5000/api/v1/',
     // baseUrl: 'https://rakib5000.binarybards.online/api/v1/',


### PR DESCRIPTION
Switch from IP-based endpoints to the official production domain (api.giftmein.com) for both environment variables and API configuration to ensure consistent and secure API access